### PR TITLE
use context cancel func to close

### DIFF
--- a/cmd/client/command_exit.go
+++ b/cmd/client/command_exit.go
@@ -9,6 +9,6 @@ import (
 func commandExit(cfg *apiConfig, arg string) error {
     fmt.Println("Closing FTP direct... Goodbye!")
     cfg.ws.WriteMessage(websocket.CloseMessage, []byte{})
-    cfg.ctx.Done()
+    cfg.ctxCancel()
     return nil
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 type apiConfig struct {
-    ctx        context.Context
+    ctxCancel  context.CancelFunc
     ftpdDir    string
     ws         *websocket.Conn
     tcpConn    *net.TCPConn
@@ -70,7 +70,7 @@ func main() {
     defer conn.Close()
 
     cfg := &apiConfig{
-        ctx: ctx,
+        ctxCancel: cancel,
         ftpdDir: saveDir,
         ws: conn,
         internal: *internalFlag,
@@ -97,7 +97,7 @@ func main() {
 
     for {
         select {
-        case <-cfg.ctx.Done():
+        case <-ctx.Done():
             return
         case <-interrupt:
             commandExit(cfg, "")


### PR DESCRIPTION
this should fix the issue of holding after closing ftpdirect